### PR TITLE
Write go.mod file for modern Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/gmelodie/xcreep
+
+go 1.11
+
+require github.com/atotto/clipboard v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=


### PR DESCRIPTION
Solves the following problem when running `go run xcreep.go`
```
xcreep.go:8:2: no required module provides package github.com/atotto/clipboard: go.mod file not found in current directory or any parent directory; see 'go help modules'
```